### PR TITLE
Exclude libraries affected by CVEs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,12 @@ repositories {
 
 dependencies {
     compile group: 'org.rundeck', name: 'rundeck-core', version: '2.10.1'
-    pluginLibs group: 'org.codehaus.groovy.modules.http-builder', name: 'http-builder', version: '0.7.1'
+    pluginLibs (group: 'org.codehaus.groovy.modules.http-builder', name: 'http-builder', version: '0.7.1') {
+        exclude (group: "commons-collections", module: "commons-collections")
+        exclude (group: "commons-beanutils", module: "commons-beanutils")
+    }
+    // bump xerces version brought by http-builder affected by CVE-2012-0881
+    pluginLibs("xerces:xercesImpl:2.12.0")
     pluginLibs group: 'com.google.code.gson', name: 'gson', version: '2.8.2'
     pluginLibs group: 'com.esotericsoftware.yamlbeans', name: 'yamlbeans', version: '1.13'
 


### PR DESCRIPTION
- Excludes unsecure versions of libraries already included in rundeck bundle.
- bumps unsecure version of xerces lib.